### PR TITLE
Update service_slim_fcsw to latest

### DIFF
--- a/src/fsharp/service/FSharpCheckerResults.fsi
+++ b/src/fsharp/service/FSharpCheckerResults.fsi
@@ -92,8 +92,6 @@ type internal TypeCheckInfo =
         sSymbolUses: TcSymbolUses *
         sFallback: NameResolutionEnv *
         loadClosure : LoadClosure option *
-        reactorOps : IReactorOperations *
-        textSnapshotInfo: obj option *
         implFileOpt: TypedImplFile option *
         openDeclarations: OpenDeclaration[]
             -> TypeCheckInfo
@@ -114,7 +112,6 @@ type public FSharpCheckFileResults =
         scopeOptX: TypeCheckInfo option *
         dependencyFiles: string[] *
         builderX: IncrementalBuilder option *
-        reactorOpsX: IReactorOperations *
         keepAssemblyContents: bool
             -> FSharpCheckFileResults
 


### PR DESCRIPTION
Many changes here because the branch `feature/fcsw` was rebased to latest `main`.

Rebasing is simpler if you want to do it yourself to keep the branch cleaner, I only had to do these changes to fix the build: https://github.com/ncave/fsharp/pull/5/commits/8981cbb2aba0602af45915ad3839a7a3456159d6