### PR TITLE
Disable CheckInlineValueIsComplete for Fable

### DIFF
--- a/src/fsharp/Optimizer.fs
+++ b/src/fsharp/Optimizer.fs
@@ -491,10 +491,18 @@ let rec IsPartialExprVal x =
     | ValValue (_, a) 
     | SizeValue(_, a) -> IsPartialExprVal a
 
+#if FABLE_CLI
+// Many Fable packages inline functions that access internal values to resolve generics, this is not an issue
+// in "normal" Fable compilations but it raises errors when generating an assembly por precompilation. Disable
+// for Fable as it's not an actual error (and if is, we assume it's already been raised during type chedking).
+let CheckInlineValueIsComplete (_v: Val) _res =
+    ()
+#else
 let CheckInlineValueIsComplete (v: Val) res =
     if v.MustInline && IsPartialExprVal res then
         errorR(Error(FSComp.SR.optValueMarkedInlineButIncomplete(v.DisplayName), v.Range))
         //System.Diagnostics.Debug.Assert(false, sprintf "Break for incomplete inline value %s" v.DisplayName)
+#endif
 
 let check (vref: ValRef) (res: ValInfo) =
     CheckInlineValueIsComplete vref.Deref res.ValExprInfo


### PR DESCRIPTION
Not entirely sure about this so I'm opening the PR for discussion. It happens that many Fable-compatible libraries include code under `FABLE_COMPILER` that inline functions accessing internal values in order to resolve generics. This code gives no errors when compiling everything as a single project as Fable normally does, but id does fail when generating a .dll assembly. I've noticed that by disabling the `CheckInlineValueIsComplete` in Optimizer.fs the error disappears. So I thought we could remove it when compiling FCS for Fable. I chose `FABLE_CLI` because this is not meant to be compiled to JS.

What do you think @ncave?